### PR TITLE
Add ParentDir and Relative path to the FileInfo

### DIFF
--- a/fileserver.go
+++ b/fileserver.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gofiber/fiber/v2/log"
+	log "github.com/sirupsen/logrus"
 )
 
 func NewFileServer(rootDir, tempDir string) *FileServer {
@@ -74,6 +74,8 @@ func (fs *FileServer) GetFiles(path string, skip, limit int, sortBy, order strin
 			FileType:     fileType,
 			Owner:        fs.getFileOwner(info),
 			FullName:     entry.Name(),
+			ParentDir:    path,                              // the requested path
+			RelPath:      filepath.Join(path, entry.Name()), // requested path + file name
 		})
 	}
 
@@ -120,6 +122,9 @@ func (fs *FileServer) GetFiles(path string, skip, limit int, sortBy, order strin
 	if limit > 0 && limit < len(paginatedFiles) {
 		paginatedFiles = paginatedFiles[:limit]
 	}
+	if len(paginatedFiles) == 0 {
+		paginatedFiles = []FileInfo{}
+	}
 	return &FilePiResonse{
 		TotalFiles: totalFiles,
 		Files:      paginatedFiles,
@@ -133,6 +138,7 @@ func (fs *FileServer) GetVideos(path string, skip, limit int, recursive bool, so
 	if err != nil {
 		return nil, err
 	}
+	requestedPath := path
 	var videoContents []FileInfo
 	err = filepath.Walk(absPath, func(path string, info os.FileInfo, err error) error {
 
@@ -155,6 +161,8 @@ func (fs *FileServer) GetVideos(path string, skip, limit int, recursive bool, so
 					FileType:     mimeType,
 					Owner:        fs.getFileOwner(info),
 					FullName:     relPath,
+					ParentDir:    requestedPath,
+					RelPath:      filepath.Join(requestedPath, relPath),
 				})
 			}
 		}
@@ -205,6 +213,9 @@ func (fs *FileServer) GetVideos(path string, skip, limit int, recursive bool, so
 	if limit > 0 && limit < len(paginatedFiles) {
 		paginatedFiles = paginatedFiles[:limit]
 	}
+	if len(paginatedFiles) == 0 {
+		paginatedFiles = []FileInfo{}
+	}
 	return &FilePiResonse{
 		TotalFiles: totalFiles,
 		Files:      paginatedFiles,
@@ -233,6 +244,8 @@ func (fs *FileServer) Search(query, path string, skip, limit int, sortBy, order 
 				FileType:     mime.TypeByExtension(filepath.Ext(info.Name())),
 				Owner:        fs.getFileOwner(info),
 				FullName:     strings.TrimPrefix(path, fs.RootDir),
+				ParentDir:    path,
+				RelPath:      filepath.Join(path, strings.TrimPrefix(path, fs.RootDir)),
 			})
 		}
 		return nil

--- a/model.go
+++ b/model.go
@@ -20,6 +20,10 @@ type FileInfo struct {
 	ModifiedTime int64  `json:"modified_time"`
 	FileType     string `json:"file_type,omitempty"`
 	Owner        string `json:"owner"`
+	// the parent directory of the file
+	ParentDir string `json:"parent_dir,omitempty"`
+	// path to file from $FILE_PI_ROOT_DIR
+	RelPath string `json:"rel_path,omitempty"`
 }
 
 type FilePiResonse struct {


### PR DESCRIPTION
- For the TV app, it is finding difficulty in displaying the filepath correctly,
- This commit adds the ParentDir and Relative path to the FileInfo struct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- File and video retrieval now include additional metadata for enhanced context, including `ParentDir` and `RelPath`.
- **Bug Fixes**
	- Improved handling of queries that return no files or videos, ensuring consistent, empty responses.
- **Chores**
	- Upgraded logging mechanisms for better diagnostic support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->