### PR TITLE
Let the user change the default http port

### DIFF
--- a/.github/workflows/on-tag-push-create-release.yml
+++ b/.github/workflows/on-tag-push-create-release.yml
@@ -212,7 +212,7 @@ jobs:
         1. Download: \`filepi_${TAG_NAME}_<arch>.deb\`
         2. Install: \`sudo dpkg -i filepi_${TAG_NAME}_<arch>.deb\`
         
-        Service starts automatically on port 8080.
+        Service starts automatically on port 8080. Access at \`http://[device-ip]:8080\`
         
         ### Binary
         1. Download: \`filepi-${TAG_NAME}-linux-<arch>.tar.gz\`
@@ -226,7 +226,8 @@ jobs:
         📚 **[Full Documentation](README.md)** - Features, API endpoints, configuration options, and development setup
         
         ## Access Your Files
-        - **Android Tv:** [PiTV explorer Android TV App](https://github.com/renjuashokan/PiTVExplorer)
+        - **Web Browser:** \`http://[device-ip]:[port]\` (default port 8080)
+        - **Android TV:** [PiTV explorer Android TV App](https://github.com/renjuashokan/PiTVExplorer)
         - **Mobile:** [Pi View app](https://github.com/renjuashokan/pi_view)
         
         EOF

--- a/DEBIAN-INSTALL.md
+++ b/DEBIAN-INSTALL.md
@@ -28,6 +28,7 @@ This document provides instructions for installing FilePi using the Debian packa
 
 - The FilePi service will be automatically enabled and started
 - Files are served from `/var/lib/filepi/media` by default
+- Service runs on port 8080 by default
 
 ## Configuration
 
@@ -42,6 +43,24 @@ This document provides instructions for installing FilePi using the Debian packa
    ```ini
    [Service]
    Environment=FILE_PI_ROOT_DIR=/your/preferred/path
+   ```
+
+3. Restart the service:
+   ```bash
+   sudo systemctl restart filepi.service
+   ```
+
+### Changing the server port
+
+1. Edit the systemd service file:
+   ```bash
+   sudo systemctl edit filepi.service
+   ```
+
+2. Add the following lines:
+   ```ini
+   [Service]
+   Environment=FILE_PI_PORT=8012
    ```
 
 3. Restart the service:
@@ -66,6 +85,21 @@ This document provides instructions for installing FilePi using the Debian packa
    ```bash
    sudo systemctl restart filepi.service
    ```
+
+### Multiple configuration options
+
+You can combine multiple environment variables in a single override:
+
+```bash
+sudo systemctl edit filepi.service
+```
+
+```ini
+[Service]
+Environment=FILE_PI_ROOT_DIR=/your/preferred/path
+Environment=FILE_PI_PORT=8012
+Environment=FILE_PI_LOGLEVEL=INFO
+```
 
 ## Service Management
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ brew install ffmpeg
 # Set the root directory for file browsing
 export FILE_PI_ROOT_DIR=/path/to/your/files
 
+# Optional: Set custom port (default: 8080)
+export FILE_PI_PORT=3000
+
 # Optional: Set log level (DEBUG, INFO, WARN, ERROR)
 export FILE_PI_LOGLEVEL=INFO
 ```
@@ -51,7 +54,7 @@ export FILE_PI_LOGLEVEL=INFO
 
 ### 4. Access the File Browser
 
-- Web interface: Open `http://[device-ip]:8080` in your browser
+- Web interface: Open `http://[device-ip]:[port]` in your browser (default port: 8080)
 - Mobile: Install the [Pi View app](https://github.com/renjuashokan/pi_view) and connect to your device
 
 ## API Endpoints
@@ -72,7 +75,23 @@ export FILE_PI_LOGLEVEL=INFO
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `FILE_PI_ROOT_DIR` | Current directory | Root directory for file browsing |
+| `FILE_PI_PORT` | 8080 | Port number for the HTTP server |
 | `FILE_PI_LOGLEVEL` | INFO | Log level (DEBUG, INFO, WARN, ERROR) |
+
+## Examples
+
+### Running on different ports
+
+```bash
+# Run on port 3000
+FILE_PI_PORT=3000 ./filepi
+
+# Run on port 9090 with custom directory
+FILE_PI_PORT=9090 FILE_PI_ROOT_DIR=/home/user/media ./filepi
+
+# Run with all custom settings
+FILE_PI_PORT=8888 FILE_PI_ROOT_DIR=/srv/files FILE_PI_LOGLEVEL=DEBUG ./filepi
+```
 
 ## Mobile App
 

--- a/main.go
+++ b/main.go
@@ -34,9 +34,15 @@ func main() {
 	}
 	log.Infof("Root directory: %s", rootDir)
 
+	port := os.Getenv("FILE_PI_PORT")
+	if port == "" {
+		port = HTTP_PORT
+	}
+	log.Infof("Server will start on port: %s", port)
+
 	tempDir := filepath.Join(rootDir, ".cache")
 
 	fs := NewFileServer(rootDir, tempDir)
 	log.Info("Starting server on root directory: ->", rootDir)
-	setupRoutes(fs)
+	setupRoutes(fs, port)
 }

--- a/router.go
+++ b/router.go
@@ -35,7 +35,7 @@ func RequestLogger() fiber.Handler {
 	}
 }
 
-func setupRoutes(fs *FileServer) {
+func setupRoutes(fs *FileServer, port string) {
 
 	// Configure Fiber with appropriate settings for file uploads
 	app := fiber.New(fiber.Config{
@@ -269,6 +269,6 @@ func setupRoutes(fs *FileServer) {
 		})
 	})
 
-	log.Info("Starting server on port 8080")
-	log.Fatal(app.Listen(":8080"))
+	log.Infof("Starting server on port %s", port)
+	log.Fatal(app.Listen(":" + port))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for configuring the server port via the `FILE_PI_PORT` environment variable, allowing users to run the service on a custom port.
- **Documentation**
	- Updated installation and configuration guides to include instructions for setting a custom port and combining multiple environment variable settings.
	- Clarified web interface access instructions to reflect customizable port usage.
	- Improved release notes to provide clearer guidance on accessing the service after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->